### PR TITLE
[enhancement] Resolve global scope syntax and urllib3 version compatibility

### DIFF
--- a/console.py
+++ b/console.py
@@ -12,7 +12,6 @@ import json
 
 VERIFY = True
 
-
 class CommandCompleter(object):
     def __init__(self):
         self.options = {
@@ -111,7 +110,6 @@ def show_help():
 
 if __name__ == '__main__':
     options = parseArgs()
-    global VERIFY
 
     if not options.target.startswith("https://") and not options.target.startswith("http://"):
         options.target = "http://" + options.target

--- a/console.py
+++ b/console.py
@@ -118,7 +118,10 @@ if __name__ == '__main__':
         # Disable warings of insecure connection for invalid certificates
         requests.packages.urllib3.disable_warnings()
         # Allow use of deprecated and weak cipher methods
-        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
+        try:
+            requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
+        except AttributeError:
+            pass
         try:
             requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
         except AttributeError:
@@ -129,6 +132,8 @@ if __name__ == '__main__':
     running = True
     while running:
         cmd = input("[webshell]> ").strip()
+        if len(cmd) == 0:
+            continue
         args = cmd.lower().split(" ")
 
         if args[0] == "exit":
@@ -144,4 +149,3 @@ if __name__ == '__main__':
                 remote_download(options.target, remote_path=args[1], local_path=args[2])
         else:
             remote_exec(options.target, cmd, verbose=options.verbose)
-


### PR DESCRIPTION
- The global VERIFY statement was removed from the main block because it was redundant and caused a SyntaxError. 
- An AttributeError was also fixed by adding try-except blocks around SSL cipher modifications, allowing the script to support newer versions of the urllib library where DEFAULT_CIPHERS is restricted. 

This version has been verified on two different exegol environments with different versions of urllib3.